### PR TITLE
feat: Update to CPython version 3.8.11 base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-build-base'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-build-base'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-build-base'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-build-base'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=neubauergroup/centos-build-base
           VERSION=latest
-          PYTHON_VERSION=3.8.10
+          PYTHON_VERSION=3.8.11
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=neubauergroup/centos-python3:3.8.10
+ARG BUILDER_IMAGE=neubauergroup/centos-python3:3.8.11
 FROM ${BUILDER_IMAGE} as builder
 
 USER root


### PR DESCRIPTION
Update to use [CPython version `3.8.11`](https://www.python.org/downloads/release/python-3811/).

```
* Update to use CPython version 3.8.11 base image
   - c.f. neubauergroup/centos-python3:3.8.11
```